### PR TITLE
fix: respect tier parameter over TOOL_MODEL env var

### DIFF
--- a/clarissa_core/llm.py
+++ b/clarissa_core/llm.py
@@ -528,19 +528,27 @@ def _convert_messages_to_claude_format(messages: list[dict]) -> list[dict]:
 def _get_tool_model(tier: ModelTier | None = None) -> str:
     """Get the model to use for tool calling.
 
-    Checks TOOL_MODEL env var first, then falls back to tier-based selection.
+    Priority:
+    1. If an explicit tier is passed, use tier-based selection
+    2. If TOOL_MODEL env var is set (non-empty), use it as the default
+    3. Otherwise, use tier-based selection with the default tier
 
     Args:
-        tier: Optional tier override. If None, uses default tier.
+        tier: Optional tier override. If provided, tier-based selection is used.
     """
-    # Explicit TOOL_MODEL takes priority
-    if tool_model := os.getenv("TOOL_MODEL"):
-        return tool_model
-
-    # Use tier-based model selection
     provider = os.getenv("LLM_PROVIDER", "openrouter").lower()
-    effective_tier = tier or get_current_tier()
-    return get_model_for_tier(effective_tier, provider)
+
+    # If explicit tier is passed, always use tier-based selection
+    if tier is not None:
+        return get_model_for_tier(tier, provider)
+
+    # Check for TOOL_MODEL as default when no tier specified
+    tool_model_env = os.getenv("TOOL_MODEL", "")
+    if tool_model_env:
+        return tool_model_env
+
+    # Fall back to tier-based selection with default tier
+    return get_model_for_tier(get_current_tier(), provider)
 
 
 def make_llm_with_tools(
@@ -558,7 +566,8 @@ def make_llm_with_tools(
     Args:
         tools: List of tool definitions in OpenAI format. If None, no tools.
         tier: Optional model tier ("high", "mid", "low").
-              If None, uses the default tier from MODEL_TIER env var or "mid".
+              If provided, overrides TOOL_MODEL env var.
+              If None, uses TOOL_MODEL env var or default tier.
 
     Returns:
         Function that calls the LLM with tool support.


### PR DESCRIPTION
## Summary

Fixes #7 - TOOL_MODEL env var was overriding all tier-based model selection.

## Problem

When `TOOL_MODEL` environment variable was set, it **always** took priority over the `tier` parameter passed to `make_llm_with_tools()`. This made tier-based selection useless when a default tool model was configured.

```python
# Before: This always used TOOL_MODEL, ignoring tier="high"
llm = make_llm_with_tools(tools, tier="high")
```

## Solution

Changed priority order in `_get_tool_model()`:

1. **If explicit tier is passed** → use tier-based selection (new!)
2. **If TOOL_MODEL env var is set** → use it as the default
3. **Otherwise** → use tier-based selection with default tier

## Changes

- Updated `_get_tool_model()` to check `tier is not None` before falling back to `TOOL_MODEL`
- Updated docstrings for `_get_tool_model()` and `make_llm_with_tools()` to clarify behavior

## Testing

```python
# With TOOL_MODEL=some-default-model

# Uses tier-based selection (tier override)
llm = make_llm_with_tools(tools, tier="high")  # → high tier model

# Uses TOOL_MODEL (no tier specified)  
llm = make_llm_with_tools(tools)  # → some-default-model

# Without TOOL_MODEL set, uses default tier
llm = make_llm_with_tools(tools)  # → mid tier model
```